### PR TITLE
Prevent error in non-editor tabs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 export const entry = ({ Notification, RunningConfig, Menu, StaticConfig }) => {
-    RunningConfig.on('aTabHasBeenCreated', ({ client, instance, directory, tabElement }) => {
+    RunningConfig.on('aTabHasBeenCreated', ({ client, instance, directory, tabElement, isEditor }) => {
+        if(!isEditor) return
         client.do('onChanged', {
             instance,
             action() {


### PR DESCRIPTION
## Reason
Custom tabs do not have a EditorClient, so 'client' is null. 

## Fix
Instantly return the function if the tab is not an editor by using 'isEditor' property.